### PR TITLE
#5 Añadir clase `Floor` con propiedades inicializadas

### DIFF
--- a/FQPClassLibraryProject/Floor.cs
+++ b/FQPClassLibraryProject/Floor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FQPClassLibraryProject
+{
+    public class Floor
+    {
+        public string Id { get; set; } = System.Guid.NewGuid().ToString();
+        public int FloorNumber { get; set; } = -666;
+        public List<Apartment> apartments { get; set; } = new List<Apartment>();
+        public bool HasLift { get; set; } = false;
+        
+        public Floor() { }
+    }
+}
+


### PR DESCRIPTION
Se ha creado una nueva clase `Floor` en `Floor.cs`, que incluye propiedades para `Id`, `FloorNumber`, `apartments` y `HasLift`. La propiedad `Id` se inicializa con un nuevo GUID, `FloorNumber` se establece en -666, `apartments` se inicializa como una lista vacía de `Apartment`, y `HasLift` se establece en `false`. También se incluye un constructor vacío.